### PR TITLE
Don't specify centroid as the only way to turn an area to a point

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -53,7 +53,7 @@ This layer contains inland water bodies and glaciers.
 
 ### Layer "water\_polygons\_labels"
 
-Holds point (centroid) geometries and names for all named water polygons available in the *water\_polygons* layer.
+Holds point geometries and names for all named water polygons available in the *water\_polygons* layer.
 
 The `way_area` attributes allows you to prefer labels of larger areas.  Features are sorted by `way_area` in
 descending order.
@@ -350,7 +350,7 @@ zoom 14 on.
 
 ### Layer "addresses"
 
-Has points for everything with an address from zoom 14+. Polygons are represented by their centroid.
+Has points for everything with an address from zoom 14+. Polygons are represented by a point.
 
 If a feature is available in the *pois* layer, it will not be duplicated in the *addresses* layer.
 
@@ -619,7 +619,7 @@ The following features are available in this layer:
 
 ### Layer "public\_transport"
 
-Holds public transport stops as points. Areas in OSM are represented by their centroid.
+Holds public transport stops as points. Areas in OSM are represented by a point.
 
 #### Properties
 
@@ -647,7 +647,7 @@ Holds public transport stops as points. Areas in OSM are represented by their ce
 
 ### Layer "pois"
 
-Holds points of interest as point geometries. Areas in OSM are represented by their centroid.
+Holds points of interest as point geometries. Areas in OSM are represented by a point.
 
 All features are available on zoom level 14 only.
 


### PR DESCRIPTION
Different implementations may prefer different ways of turning polygons into points, and this lets them experiment with new ways. Additionally, the centroid is a particularly bad algorithm as it may lay outside the polygon.