### PR TITLE
fix typo in wiki links

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -582,15 +582,15 @@ Holds aerialways as lines.
 
 | Feature Class   | value of `kind` | OSM Tag                           | Zoom |
 | --------------- | :-------------- | :-------------------------------- | :--- |
-| cable car       | `cable_car`     | {{< tag aerialways cable_car >}}  | 12+  |
-| gondola         | `gondola`       | {{< tag aerialways gondola >}}    | 12+  |
-| goods cable car | `goods`         | {{< tag aerialways goods >}}      | 12+  |
-| chair lift      | `chair_lift`    | {{< tag aerialways chair_lift >}} | 12+  |
-| drag lift       | `drag_lift`     | {{< tag aerialways drag_lift >}}  | 12+  |
-| t-bar lift      | `t-bar`         | {{< tag aerialways t-bar >}}      | 12+  |
-| j-bar lift      | `j-bar`         | {{< tag aerialways j-bar >}}      | 12+  |
-| platter lift    | `platter`       | {{< tag aerialways platter >}}    | 12+  |
-| rope-tow lift   | `rope-tow`      | {{< tag aerialways rope_tow >}}   | 12+  |
+| cable car       | `cable_car`     | {{< tag aerialway cable_car >}}  | 12+  |
+| gondola         | `gondola`       | {{< tag aerialway gondola >}}    | 12+  |
+| goods cable car | `goods`         | {{< tag aerialway goods >}}      | 12+  |
+| chair lift      | `chair_lift`    | {{< tag aerialway chair_lift >}} | 12+  |
+| drag lift       | `drag_lift`     | {{< tag aerialway drag_lift >}}  | 12+  |
+| t-bar lift      | `t-bar`         | {{< tag aerialway t-bar >}}      | 12+  |
+| j-bar lift      | `j-bar`         | {{< tag aerialway j-bar >}}      | 12+  |
+| platter lift    | `platter`       | {{< tag aerialway platter >}}    | 12+  |
+| rope-tow lift   | `rope-tow`      | {{< tag aerialway rope_tow >}}   | 12+  |
 
 ### Layer "ferries"
 


### PR DESCRIPTION
It's aerialway, not aerialways. The documentation currently links to non-existing wiki articles.