### PR TITLE
Move historic=artwork to tourism=artwork

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -753,7 +753,6 @@ The following key-value combinations are included in this layer:
 - {{< tag emergency phone >}}
 - {{< tag highway emergency_access_point >}}
 - {{< tag historic archaelogical_site >}}
-- {{< tag historic artwork >}}
 - {{< tag historic battlefield >}}
 - {{< tag historic castle >}}
 - {{< tag historic fort >}}
@@ -816,6 +815,7 @@ The following key-value combinations are included in this layer:
 - {{< tag shop toys >}}
 - {{< tag shop travel_agency >}}
 - {{< tag shop video >}}
+- {{< tag tourism artwork >}}
 - {{< tag tourism alpine_hut >}}
 - {{< tag tourism bed_and_breakfast >}}
 - {{< tag tourism camp_site >}}


### PR DESCRIPTION
This appears to be an error in the specification, as the latter is used in OSM while the former is not. I believe we can make this fix to 1.0 because it's an obvious mistake and historic=artwork isn't used.

Fixes #54