### PR TITLE
Update license text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ may be visible in the Git history.
 
 ## License and Copyright
 
-Geofabrik takes the position that this schema is not creative enough to be a copyrightable
-work. For the sake of clarity, however, we are releasing it under the [CC-0 license.](./LICENSE.md)
+We take the position that this schema is not creative enough to be a copyrightable
+work. For the sake of clarity, however, we are releasing it under the [CC-0 license](./LICENSE.md).
 For the avoidance of doubt, using this schema to create your vector tiles will not add any attribution
 requirements, but if you generate vector tiles from OpenStreetMap data, you will of course have
 to attribute OpenStreetMap.

--- a/shortbread-website/content/make-vectortiles/planetiler.md
+++ b/shortbread-website/content/make-vectortiles/planetiler.md
@@ -17,6 +17,7 @@ Shortbread Tiles can be created with [Planetiler](https://github.com/onthegomap/
 ### Quickstart (Docker)
 
 ```bash
+mkdir data
 docker run --rm --user=$UID -v $PWD/data:/data ghcr.io/onthegomap/planetiler shortbread.yml \
   --download --area=liechtenstein --output=/data/shortbread.pmtiles
 ```


### PR DESCRIPTION
and fix directory permission in planetiler tutorial.

The "See also" chapter in in README.md should maybe better included in the "Creating Shortbread Vector Tiles" chapter.