### PR TITLE
Remove staging deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,11 +33,3 @@ jobs:
           eval $(ssh-agent -s)
           ssh-add - <<< "${SSH_KEY}"
           rsync --exclude=/w --delete -r -e "ssh -o StrictHostKeyChecking=no -p 22" shortbread-website/public/ web@web2.fossgis.de:/
-      - name: Deploy site (staging)
-        if: github.ref == 'refs/heads/staging'
-        env:
-          SSH_KEY: ${{ secrets.SSH_KEY_STAGING }}
-        run: |
-          eval $(ssh-agent -s)
-          ssh-add - <<< "${SSH_KEY}"
-          rsync --exclude=/w --delete -r -e "ssh -o StrictHostKeyChecking=no -p 22" shortbread-website/public/ web@web2.fossgis.de:/


### PR DESCRIPTION
https://staging.shortbread-tiles.org/ has been decomissioned and main branch is now deployed to https://shortbread-tiles.org/