### PR TITLE
fix: typo in pier_polygons

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -174,9 +174,9 @@ This layer contains piers, breakwaters and groynes mapped as polygons. See the _
 
 | `kind`     | OSM Tags                        | Geometry | Zoom |
 | ---------- | :------------------------------ | :------- | :--- |
-| pier       | {{< tag man_made pier >}}       | line     | 12+  |
-| breakwater | {{< tag man_made breakwater >}} | line     | 12+  |
-| groyne     | {{< tag man_made groyne >}}     | line     | 12+  |
+| pier       | {{< tag man_made pier >}}       | polygon  | 12+  |
+| breakwater | {{< tag man_made breakwater >}} | polygon  | 12+  |
+| groyne     | {{< tag man_made groyne >}}     | polygon  | 12+  |
 
 ## Countries, States, Cities
 


### PR DESCRIPTION
This fixes one of the typos found during verifying/fixing the planetiler impl of the spec.