### PR TITLE
fix: typo in `narrow_guage` specification in `streets`

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -414,7 +414,7 @@ The following features are available in this layer:
 | runway                              | `runway`        | 11+   |                                                                                      |
 | taxiway                             | `taxiway`       | 13+   |                                                                                      |
 | railway                             | `rail`          | 8/10+ | ways with {{< tag service >}} on zoom level 8+, other ways on zoom level 10+         |
-| narrow gauge railway                | `narrow_gauge`  | 8+    | ways with {{< tag service >}} on zoom level 8+, other ways on zoom level 10+         |
+| narrow gauge railway                | `narrow_gauge`  | 8/10+ | ways with {{< tag service >}} on zoom level 8+, other ways on zoom level 10+         |
 | tram                                | `tram`          | 10+   |                                                                                      |
 | light railway                       | `light_rail`    | 10+   |                                                                                      |
 | funicular                           | `funicular`     | 10+   |                                                                                      |


### PR DESCRIPTION
This makes it consistent with the line above