### PR TITLE
fix: missing tunnel definition for `street_labels`

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -463,7 +463,7 @@ This layer holds street geometries for labelling. It contains their names and re
 | `name`     | string  | value of OSM {{< tag name >}} tag                                                                |
 | `name_en`  | string  | value of OSM {{< tag "name:en" >}} tag                                                           |
 | `name_de`  | string  | value of OSM {{< tag "name:de" >}} tag                                                           |
-| `tunnel`   | boolean |
+| `tunnel`   | boolean | `true` for {{< tag tunnel yes building_passage >}} or {{< tag covered yes >}}. `false` otherwise |
 
 #### Features
 


### PR DESCRIPTION
more of a spec-change than the others, but still likely just a bugfix