### PR TITLE
Add `leisure=park` to `pois` layer

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -762,6 +762,7 @@ The following key-value combinations are included in this layer:
 - {{< tag historic wayside_shrine >}}
 - {{< tag leisure golf_course >}}
 - {{< tag leisure ice_rink >}}
+- {{< tag leisure park >}}
 - {{< tag leisure pitch >}}
 - {{< tag leisure sports_centre >}}
 - {{< tag leisure stadium >}}

--- a/shortbread-website/content/schema/1.1.md
+++ b/shortbread-website/content/schema/1.1.md
@@ -762,6 +762,7 @@ The following key-value combinations are included in this layer:
 - {{< tag historic wayside_shrine >}}
 - {{< tag leisure golf_course >}}
 - {{< tag leisure ice_rink >}}
+- {{< tag leisure park >}}
 - {{< tag leisure pitch >}}
 - {{< tag leisure sports_centre >}}
 - {{< tag leisure stadium >}}


### PR DESCRIPTION
This mimics the `leisure=golf_course` which is present in both the `land` and `pois` layers.

Given this change fits the following line from the versioning guidelines:
>- adding a new `kind` to a table if the new `kind` doesn't change the overall meaning of the layer;

This change includes a bump to `1.1.md`. Let me know if the naming/pattern of `1.1.md` doesn't fit the goal of the version changes.