### PR TITLE
streets: Correct flipped zooms for rails

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -415,8 +415,8 @@ The following features are available in this layer:
 | bicycle paths                       | `cycleway`      | 13+   |                                                                                      |
 | runway                              | `runway`        | 11+   |                                                                                      |
 | taxiway                             | `taxiway`       | 13+   |                                                                                      |
-| railway                             | `rail`          | 8/10+ | ways with {{< tag service >}} on zoom level 8+, other ways on zoom level 10+         |
-| narrow gauge railway                | `narrow_gauge`  | 8/10+ | ways with {{< tag service >}} on zoom level 8+, other ways on zoom level 10+         |
+| railway                             | `rail`          | 8/10+ | ways with {{< tag service >}} on zoom level 10+, other ways on zoom level 8+         |
+| narrow gauge railway                | `narrow_gauge`  | 8/10+ | ways with {{< tag service >}} on zoom level 10+, other ways on zoom level 8+         |
 | tram                                | `tram`          | 10+   |                                                                                      |
 | light railway                       | `light_rail`    | 10+   |                                                                                      |
 | funicular                           | `funicular`     | 10+   |                                                                                      |


### PR DESCRIPTION
Having unimportant rail appear before important rail doesn't make sense. This corrects an error when writing the spec.

Fixes #47