### PR TITLE
Add access information to roads

### DIFF
--- a/shortbread-website/content/schema/1.1.md
+++ b/shortbread-website/content/schema/1.1.md
@@ -399,8 +399,41 @@ from road class, OSM {{< tag layer >}}, {{< tag bridge >}} and {{< tag tunnel >}
 | `tracktype`      | string  | 11+  | field not available | value of {{< tag tracktype >}}                                                                                             |
 | `surface`        | string  | 11+  | empty string        | value of {{< tag surface >}}                                                                                               |
 | `service`        | string  | 11+  | field not available | value of {{< tag service >}}                                                                                               |
-| `bicycle`        | string  | 14+  | empty string        | value of {{< tag bicycle >}}                                                                                               |
-| `horse`          | string  | 14+  | empty string        | value of {{< tag horse >}}                                                                                                 |
+| `motorcar`       | string  | 13+  | field not available | Access for motorcars, only if {{< tag highway >}} is present                                                               |
+| `bicycle`        | string  | 13+  | field not available | Access for bicycles, only if {{< tag highway >}} is present                                                                |
+| `foot`           | string  | 13+  | field not available | Access for pedestrians, only if {{< tag highway >}} is present                                                             |
+| `horse`          | string  | 13+  | field not available | Access for horses, only if {{< tag highway >}} is present                                                                  |
+
+#### Access tag mapping
+
+The `motorcar`, `bicycle`, `foot`, and `horse` attributes are derived from OpenStreetMap access tags using the following mapping:
+
+| OSM tag value    | Mapped to |
+| ---------------- | :-------- |
+| `yes`            | yes       |
+| `designated`     | yes       |
+| `permissive`     | yes       |
+| `customers`      | limited   |
+| `destination`    | limited   |
+| `agricultural`   | limited   |
+| `forestry`       | limited   |
+| `delivery`       | limited   |
+| `discouraged`    | limited   |
+| `permit`         | limited   |
+| `dismount`       | no        |
+| `military`       | no        |
+| `private`        | no        |
+| `no`             | no        |
+
+Other values are removed and not considered when evaluating access tags.
+
+For each access type (motorcar, bicycle, foot, horse), the first matching OSM tag in the following priority order is used:
+- `motorcar`: {{< tag motorcar >}}, {{< tag motor_vehicle >}}, {{< tag vehicle >}}, {{< tag access >}}
+- `bicycle`: {{< tag bicycle >}}, {{< tag vehicle >}}, {{< tag access >}}
+- `foot`: {{< tag foot >}}, {{< tag access >}}
+- `horse`: {{< tag horse >}}, {{< tag access >}}
+
+If no access tags are present the property is not present. Access is only evaulated for {{< tag highway >}} objects; railways and aeroways do not have `motorcar`, `bicycle`, `foot`, or `horse` properties.
 
 #### Features
 


### PR DESCRIPTION
This adds access information for car, bicycle, and foot to appropriate features in the streets layer.

I went with 13+ for access because that's where it's useful. Showing foot and bicycle access is of little value if you're not also showing highway=footway/cycleway/path features.

cc @simonpoole because I know he has strong opinions on mode-specific access information on general purpose maps.

Fixes #38